### PR TITLE
Add fourier-transform to benchmarks

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -4,7 +4,8 @@ const FFT = require('../');
 const external = {
   jensnockert: require('fft'),
   dspjs: require('dsp.js'),
-  drom: require('fourier')
+  drom: require('fourier'),
+  fourierTransform: require('fourier-transform')
 };
 const benchmark = require('benchmark');
 
@@ -74,6 +75,15 @@ function addDrom(suite, size) {
   });
 }
 
+function addFourierTransform(suite, size) {
+  const forward = external.fourierTransform
+
+  const input = createInput(size);
+  suite.add('fourier-transform', () => {
+    forward(input)
+  })
+}
+
 function transform(size) {
   const suite = new benchmark.Suite();
 
@@ -81,6 +91,7 @@ function transform(size) {
   addJensNockert(suite, size);
   addDSPJS(suite, size);
   addDrom(suite, size);
+  addFourierTransform(suite, size);
 
   return suite;
 }

--- a/bench/index.js
+++ b/bench/index.js
@@ -77,12 +77,12 @@ function addDrom(suite, size) {
 }
 
 function addFourierTransform(suite, size) {
-  const forward = external.fourierTransform
+  const forward = external.fourierTransform;
 
   const input = createInput(size);
   suite.add('fourier-transform', () => {
-    forward(input)
-  })
+    forward(input);
+  });
 }
 
 function transform(size) {

--- a/bench/package.json
+++ b/bench/package.json
@@ -18,6 +18,7 @@
     "benchmark": "^2.1.3",
     "dsp.js": "github:corbanbrook/dsp.js",
     "fft": "^0.2.1",
-    "fourier": "^0.2.1"
+    "fourier": "^0.2.1",
+    "fourier-transform": "^1.0.2"
   }
 }


### PR DESCRIPTION
I've added the [fourier-transform](https://github.com/scijs/fourier-transform) to the benchmark (related to #1). It seems to be the fastest but is unfair because only works with real signals and have no inverse operation.

This is the results of the benchmark in my computer:

```
===== table construction =====
    fft.js x 1,266 ops/sec ±1.98% (86 runs sampled)
  Fastest is fft.js
===== transform size=2048 =====
    fft.js x 17,473 ops/sec ±2.66% (87 runs sampled)
    jensnockert x 3,900 ops/sec ±0.96% (90 runs sampled)
    dsp.js x 14,500 ops/sec ±1.10% (87 runs sampled)
    drom x 11,076 ops/sec ±1.05% (86 runs sampled)
    fourier-transform x 23,630 ops/sec ±0.99% (90 runs sampled)
  Fastest is fourier-transform
===== transform size=4096 =====
    fft.js x 8,835 ops/sec ±0.87% (88 runs sampled)
    jensnockert x 2,997 ops/sec ±1.14% (89 runs sampled)
    dsp.js x 5,053 ops/sec ±0.78% (92 runs sampled)
    drom x 5,143 ops/sec ±0.90% (89 runs sampled)
    fourier-transform x 11,091 ops/sec ±0.92% (89 runs sampled)
  Fastest is fourier-transform
===== transform size=8192 =====
    fft.js x 3,675 ops/sec ±0.93% (88 runs sampled)
    jensnockert x 833 ops/sec ±7.40% (81 runs sampled)
    dsp.js x 2,095 ops/sec ±0.76% (90 runs sampled)
    drom x 2,390 ops/sec ±0.85% (90 runs sampled)
    fourier-transform x 4,573 ops/sec ±0.90% (92 runs sampled)
  Fastest is fourier-transform
===== transform size=16384 =====
    fft.js x 1,792 ops/sec ±0.96% (89 runs sampled)
    jensnockert x 664 ops/sec ±1.21% (87 runs sampled)
    dsp.js x 704 ops/sec ±0.89% (90 runs sampled)
    drom x 1,094 ops/sec ±0.79% (89 runs sampled)
    fourier-transform x 1,936 ops/sec ±0.97% (92 runs sampled)
  Fastest is fourier-transform
```

Thanks for the library, the code looks very clean and easy to understand (and I've read a lot of implementations lately). Looking forward #2 to improve speed. And probably is a good idea to have some tests to check the results (it looks like different implementations have slightly different values)

Congrats.
