### PR TITLE
bumps node & distro for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-sudo: false
 
 language: node_js
 
+os: linux
+dist: bionic
+
 node_js:
-  - "4"
-  - "6"
+  - "10"
+  - "12"
   - "stable"
 
 script:


### PR DESCRIPTION
Travis tests failing on node 4 & 6, bumps those to 10 & 12.  
- [Tests](https://travis-ci.org/github/Jesssullivan/fft.js/builds/754570001)    ([![Build Status](https://secure.travis-ci.org/jesssullivan/fft.js.svg)](http://travis-ci.org/jesssullivan/fft.js))
