### PR TITLE
fix(usage): correct parameter order in inverseTransform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ f.transform(out, data);
 
 Inverse fourier transform:
 ```js
-f.inverseTransform(data, out);
+f.inverseTransform(out, data);
 ```
 
 ## Benchmarks


### PR DESCRIPTION
Swapped 'data' and 'out' parameters in the usage example to match the correct method signature.